### PR TITLE
Feature/database/children

### DIFF
--- a/Model.php
+++ b/Model.php
@@ -87,30 +87,11 @@ abstract class Model implements Serializable
 	 * @throws PrivateException
 	 */
 	public function store() {
-		$dependencies = $this->getDependencies();
-		
-		$processed = collect([$this]);
-		
-		while ($d = $dependencies->shift()) {
-			if (!$processed->contains($d)) {
-				$processed->push($d);
-				$dependencies->add($d->getDependencies());
-			}
+		#Check if onbeforesave is there and use it.
+		if (method_exists($this, 'onbeforesave')) {
+			$this->onbeforesave();
 		}
 		
-		#Check if onbeforesave is there and use it.
-		$processed->each(function ($e) {
-			if (method_exists($e, 'onbeforesave')) {
-				$e->onbeforesave();
-			}
-		});
-		
-		$processed->each(function ($e) {
-			$e->write();
-		});
-	}
-	
-	public function write() {
 		#Decide whether to insert or update depending on the Model
 		if ($this->new) { $this->insert(); }
 		else            { $this->update(); }
@@ -120,20 +101,6 @@ abstract class Model implements Serializable
 		foreach($this->data as $value) {
 			$value->commit();
 		}
-	}
-	
-	public function getDependencies() {
-		
-		$dependencies = collect($this->data)->filter(function ($e) {
-			return $e instanceof model\adapters\ReferenceAdapter || $e instanceof model\adapters\ChildrenAdapter;
-		})
-		->each(function ($e) {
-			return $e->getDependencies();
-		})
-		->filter()
-		->flatten();
-		
-		return $dependencies;
 	}
 
 

--- a/core/Collection.php
+++ b/core/Collection.php
@@ -111,7 +111,7 @@ class Collection implements ArrayAccess, CollectionInterface
 	}
 	
 	public function contains($e) {
-		return array_search($e, $this->items);
+		return array_search($e, $this->items, true);
 	}
 	
 	/**

--- a/io/stream/SeekableStreamInterface.php
+++ b/io/stream/SeekableStreamInterface.php
@@ -24,7 +24,16 @@
  * THE SOFTWARE.
  */
 
-interface StreamInterface
+interface SeekableStreamInterface extends StreamInterface
 {
+	
+	function seek($position) : StreamInterface;
+	
+	/**
+	 * Returns the current position of the pointer.
+	 * 
+	 * @return int
+	 */
+	function tell() : int;
 	
 }

--- a/io/stream/StreamReaderInterface.php
+++ b/io/stream/StreamReaderInterface.php
@@ -29,7 +29,5 @@ interface StreamReaderInterface extends StreamInterface
 	
 	function read($length = null);
 	
-	function seek($position) : StreamInterface;
-	
 	function length() : int;
 }

--- a/io/stream/StreamSegment.php
+++ b/io/stream/StreamSegment.php
@@ -35,17 +35,13 @@ class StreamSegment implements StreamReaderInterface, SeekableStreamInterface
 	
 	private $cursor;
 	
-	public function __construct(StreamReaderInterface$src, $start, $end = null) {
+	public function __construct(SeekableStreamInterface$src, $start, $end = null) {
 		$this->src = $src;
 		$this->start = $this->cursor = $start;
 		$this->end = $end;
 		
 		if ($this->start >= $this->end) {
 			throw new \spitfire\exceptions\OutOfBoundsException('Start of stream segment is out of bounds', 1811081804);
-		}
-		
-		if (!$this->src instanceof SeekableStreamInterface) {
-			throw new \InvalidArgumentException('Segments only work on streams that allow seeking', 1811101243);
 		}
 		
 		$this->src->seek($this->start);

--- a/model/adapters/baseadapter.php
+++ b/model/adapters/baseadapter.php
@@ -163,5 +163,9 @@ abstract class BaseAdapter implements AdapterInterface
 	public function validate() {
 		return $this->field->validate($this->data);
 	}
+	
+	public function getDependencies() {
+		return [];
+	}
 
 }

--- a/model/adapters/referenceadapter.php
+++ b/model/adapters/referenceadapter.php
@@ -4,7 +4,6 @@ use spitfire\exceptions\PrivateException;
 use spitfire\Model;
 use spitfire\storage\database\Field;
 use spitfire\storage\database\Query;
-use spitfire\storage\database\Restriction;
 
 class ReferenceAdapter extends BaseAdapter
 {
@@ -43,7 +42,7 @@ class ReferenceAdapter extends BaseAdapter
 		 * TODO: This should stop being an issue once the resultset object has been
 		 * moved out of the query.
 		 */
-		$this->remote = $this->query === null? null : clone $this->query;
+		$this->remote = $this->query;
 	}
 	
 	public function dbGetData() {
@@ -58,15 +57,11 @@ class ReferenceAdapter extends BaseAdapter
 				$_return[$p->getName()] = $modeldata[$p->getReferencedField()->getName()];
 			}
 		} elseif ($this->query instanceof Query) {
-			$restrictions = $this->query->getRestrictions();
-			foreach ($restrictions as $r) {
-				/* @var $r Restriction */
-				foreach ($physical as $p) {
-					if ($r instanceof Restriction && $r->getField()->getField() === $p->getReferencedField()) {
-						$_return[$p->getName()] = $r->getValue();
-					}
-				}
-			}
+			/*
+			 * In this case, the value of the field was never changed, and therefore
+			 * there's no need to rewrite the data.
+			 */
+			return [];
 		} elseif ($this->query === null) {
 			foreach ($physical as $p) {
 				$_return[$p->getName()] = null;
@@ -96,13 +91,24 @@ class ReferenceAdapter extends BaseAdapter
 	}
 	
 	public function isSynced() {
+		if ($this->query instanceof Query) {
+			/*
+			 * If the value of the adapter was never changed, then it's safe to assume
+			 * that it's still in sync. Please note that spitfire assumes that the 
+			 * database will cascade changes if the primary key of a record is changed.
+			 * 
+			 * NOTE: The primary key of a record should NEVER change.
+			 */
+			return true;
+		}
+		
 		$this->remote = $ma = $this->remote instanceof Query? $this->remote->fetch() : $this->remote;
 		$this->query  = $mb = $this->query  instanceof Query? $this->query->fetch()  : $this->query;
 		
 		$pka = $ma? $ma->getPrimaryData() : null;
 		$pkb = $mb? $mb->getPrimaryData() : null;
 		
-		return $pka == $pkb;
+		return $pka === $pkb;
 	}
 	
 	
@@ -111,13 +117,6 @@ class ReferenceAdapter extends BaseAdapter
 	 * committing, rolling back will return the current value.
 	 */
 	public function commit() {
-		/**
-		 * If the "parent" was also edited or newly created, we should enforce 
-		 * that it is stored.
-		 */
-		if ($this->query instanceof Model) { 
-			//$this->query->store(); 
-		}
 		
 		#Now we can safely say that the data stored on the remote and local sets 
 		#is equal. Therefore we can replace the old remote value.
@@ -130,6 +129,10 @@ class ReferenceAdapter extends BaseAdapter
 	 */
 	public function rollback() {
 		$this->query = $this->remote;
+	}
+	
+	public function getDependencies() {
+		return collect($this->query instanceof Query? [] : [$this->query]);
 	}
 }
 

--- a/model/adapters/referenceadapter.php
+++ b/model/adapters/referenceadapter.php
@@ -4,6 +4,7 @@ use spitfire\exceptions\PrivateException;
 use spitfire\Model;
 use spitfire\storage\database\Field;
 use spitfire\storage\database\Query;
+use spitfire\storage\database\Restriction;
 
 class ReferenceAdapter extends BaseAdapter
 {
@@ -42,7 +43,7 @@ class ReferenceAdapter extends BaseAdapter
 		 * TODO: This should stop being an issue once the resultset object has been
 		 * moved out of the query.
 		 */
-		$this->remote = $this->query;
+		$this->remote = $this->query === null? null : clone $this->query;
 	}
 	
 	public function dbGetData() {
@@ -57,11 +58,15 @@ class ReferenceAdapter extends BaseAdapter
 				$_return[$p->getName()] = $modeldata[$p->getReferencedField()->getName()];
 			}
 		} elseif ($this->query instanceof Query) {
-			/*
-			 * In this case, the value of the field was never changed, and therefore
-			 * there's no need to rewrite the data.
-			 */
-			return [];
+			$restrictions = $this->query->getRestrictions();
+			foreach ($restrictions as $r) {
+				/* @var $r Restriction */
+				foreach ($physical as $p) {
+					if ($r instanceof Restriction && $r->getField()->getField() === $p->getReferencedField()) {
+						$_return[$p->getName()] = $r->getValue();
+					}
+				}
+			}
 		} elseif ($this->query === null) {
 			foreach ($physical as $p) {
 				$_return[$p->getName()] = null;
@@ -91,24 +96,13 @@ class ReferenceAdapter extends BaseAdapter
 	}
 	
 	public function isSynced() {
-		if ($this->query instanceof Query) {
-			/*
-			 * If the value of the adapter was never changed, then it's safe to assume
-			 * that it's still in sync. Please note that spitfire assumes that the 
-			 * database will cascade changes if the primary key of a record is changed.
-			 * 
-			 * NOTE: The primary key of a record should NEVER change.
-			 */
-			return true;
-		}
-		
 		$this->remote = $ma = $this->remote instanceof Query? $this->remote->fetch() : $this->remote;
 		$this->query  = $mb = $this->query  instanceof Query? $this->query->fetch()  : $this->query;
 		
 		$pka = $ma? $ma->getPrimaryData() : null;
 		$pkb = $mb? $mb->getPrimaryData() : null;
 		
-		return $pka === $pkb;
+		return $pka == $pkb;
 	}
 	
 	
@@ -117,6 +111,13 @@ class ReferenceAdapter extends BaseAdapter
 	 * committing, rolling back will return the current value.
 	 */
 	public function commit() {
+		/**
+		 * If the "parent" was also edited or newly created, we should enforce 
+		 * that it is stored.
+		 */
+		if ($this->query instanceof Model) { 
+			$this->query->store(); 
+		}
 		
 		#Now we can safely say that the data stored on the remote and local sets 
 		#is equal. Therefore we can replace the old remote value.
@@ -129,10 +130,6 @@ class ReferenceAdapter extends BaseAdapter
 	 */
 	public function rollback() {
 		$this->query = $this->remote;
-	}
-	
-	public function getDependencies() {
-		return collect($this->query instanceof Query? [] : [$this->query]);
 	}
 }
 

--- a/model/adapters/referenceadapter.php
+++ b/model/adapters/referenceadapter.php
@@ -4,7 +4,6 @@ use spitfire\exceptions\PrivateException;
 use spitfire\Model;
 use spitfire\storage\database\Field;
 use spitfire\storage\database\Query;
-use spitfire\storage\database\Restriction;
 
 class ReferenceAdapter extends BaseAdapter
 {
@@ -57,21 +56,16 @@ class ReferenceAdapter extends BaseAdapter
 			foreach ($physical as $p) {
 				$_return[$p->getName()] = $modeldata[$p->getReferencedField()->getName()];
 			}
-		} elseif ($this->query instanceof Query) {
-			$restrictions = $this->query->getRestrictions();
-			foreach ($restrictions as $r) {
-				/* @var $r Restriction */
-				foreach ($physical as $p) {
-					if ($r instanceof Restriction && $r->getField()->getField() === $p->getReferencedField()) {
-						$_return[$p->getName()] = $r->getValue();
-					}
-				}
-			}
-		} elseif ($this->query === null) {
+		} 
+		elseif ($this->query instanceof Query) {
+			return [];
+		} 
+		elseif ($this->query === null) {
 			foreach ($physical as $p) {
 				$_return[$p->getName()] = null;
 			}
-		} else {
+		} 
+		else {
 			throw new PrivateException('Adapter holds invalid data');
 		}
 		
@@ -96,6 +90,10 @@ class ReferenceAdapter extends BaseAdapter
 	}
 	
 	public function isSynced() {
+		if ($this->query instanceof Query) {
+			return true; //The data has not been changed
+		}
+		
 		$this->remote = $ma = $this->remote instanceof Query? $this->remote->fetch() : $this->remote;
 		$this->query  = $mb = $this->query  instanceof Query? $this->query->fetch()  : $this->query;
 		
@@ -111,14 +109,6 @@ class ReferenceAdapter extends BaseAdapter
 	 * committing, rolling back will return the current value.
 	 */
 	public function commit() {
-		/**
-		 * If the "parent" was also edited or newly created, we should enforce 
-		 * that it is stored.
-		 */
-		if ($this->query instanceof Model) { 
-			$this->query->store(); 
-		}
-		
 		#Now we can safely say that the data stored on the remote and local sets 
 		#is equal. Therefore we can replace the old remote value.
 		$this->remote = $this->query;
@@ -130,6 +120,10 @@ class ReferenceAdapter extends BaseAdapter
 	 */
 	public function rollback() {
 		$this->query = $this->remote;
+	}
+	
+	public function getDependencies() {
+		return collect($this->query instanceof Query || $this->query === null? null : $this->query);
 	}
 }
 

--- a/storage/drive/FileStreamReader.php
+++ b/storage/drive/FileStreamReader.php
@@ -1,6 +1,7 @@
 <?php namespace spitfire\storage\drive;
 
 use spitfire\exceptions\FilePermissionsException;
+use spitfire\io\stream\SeekableStreamInterface;
 use spitfire\io\stream\StreamInterface;
 use spitfire\io\stream\StreamReaderInterface;
 
@@ -28,7 +29,7 @@ use spitfire\io\stream\StreamReaderInterface;
  * THE SOFTWARE.
  */
 
-class FileStreamReader implements StreamReaderInterface
+class FileStreamReader implements StreamReaderInterface, SeekableStreamInterface
 {
 	
 	/**
@@ -88,8 +89,14 @@ class FileStreamReader implements StreamReaderInterface
 		return $this;
 	}
 	
+	
+	public function tell(): int {
+		return ftell($this->fh);
+	}
+	
 	public function length(): int {
 		return filesize($this->path);
 	}
+
 
 }

--- a/tests/storage/database/drivers/mysqlpdo/TableTest.php
+++ b/tests/storage/database/drivers/mysqlpdo/TableTest.php
@@ -1,5 +1,6 @@
 <?php namespace tests\spitfire\storage\database\drivers\mysqlpdo;
 
+use ChildrenField;
 use IntegerField;
 use PHPUnit\Framework\TestCase;
 use Reference;
@@ -79,6 +80,29 @@ class TableTest extends TestCase
 		$e2 = $this->db->table($schema2)->newRecord();
 		
 		$e2->a = $e1;
+		$e2->store();
+		
+		$this->assertNotEmpty($e1->_id);
+		$this->assertNotEmpty($e2->a->_id);
+	}
+	
+	/**
+	 * 
+	 * @depends tests\spitfire\storage\database\drivers\mysqlpdo\TableTest::testCreate
+	 */
+	public function testStoreDoubleReference($o) {
+		
+		$schema1 = new Schema('test\storage\database\Table\Double\Create1');
+		$schema2 = new Schema('test\storage\database\Table\Double\Create2');
+		
+		$schema1->b = new ChildrenField('test\storage\database\Table\Double\Create2', 'a');
+		$schema2->a = new Reference('test\storage\database\Table\Double\Create1');
+		
+		$e1 = $this->db->table($schema1)->newRecord();
+		$e2 = $this->db->table($schema2)->newRecord();
+		
+		$e2->a = $e1;
+		$e1->b[] = $e2;
 		$e2->store();
 		
 		$this->assertNotEmpty($e1->_id);


### PR DESCRIPTION
Improvements to the way children are managed on the database side of things. This now allows for full deferred storing of the data and maintains a consistent state.

Notes:

    Known bug: When changing a record's primary key, children do not inherit this change and may produce unexpected behavior.
    Refactoring needed. Some of the code in this PR is not up to the standard of the rest of the project and should be refactored.
