### PR TITLE
The providers now hint at their need for our container implementation

### DIFF
--- a/core/http/URLServiceProvider.php
+++ b/core/http/URLServiceProvider.php
@@ -3,6 +3,7 @@
 use spitfire\core\config\Configuration;
 use spitfire\core\router\Router;
 use spitfire\core\service\Provider;
+use spitfire\provider\Container;
 use spitfire\SpitFire;
 
 /**
@@ -15,10 +16,16 @@ class URLServiceProvider extends Provider
 	{
 		$config = $this->container->get(Configuration::class);
 		
-		$this->container->set(
+		/**
+		 * 
+		 * @var Container
+		 */
+		$container = $this->container->get(Container::class);
+		
+		$container->set(
 			URLBuilder::class, 
-			$this->container->assemble(URLBuilder::class, [
-				'routes' => $this->container->get(Router::class)->getRoutes(),
+			$container->assemble(URLBuilder::class, [
+				'routes' => $container->get(Router::class)->getRoutes(),
 				'root'   => SpitFire::baseUrl(),
 				'assets' => $config->get('app.assets.location', SpitFire::baseUrl() . '/assets')
 			])

--- a/io/session/SessionProvider.php
+++ b/io/session/SessionProvider.php
@@ -3,6 +3,7 @@
 use spitfire\core\config\Configuration;
 use spitfire\core\service\Provider;
 use spitfire\exceptions\ApplicationException;
+use spitfire\provider\Container;
 
 class SessionProvider extends Provider
 {
@@ -13,6 +14,13 @@ class SessionProvider extends Provider
 	
 	public function register()
 	{
+		
+		/**
+		 * 
+		 * @var Container
+		 */
+		$container = $this->container->get(Container::class);
+		
 		$config = $this->container->get(Configuration::class);
 		$settings = $config->get('spitfire.io.session');
 		
@@ -24,7 +32,7 @@ class SessionProvider extends Provider
 			 */
 			case 'file':
 				$_session = new Session(new FileSessionHandler($settings['directory']?? session_save_path()));
-				$this->container->set(Session::class, $_session);
+				$container->set(Session::class, $_session);
 				break;
 			/**
 			 * Assuming the developer selected no session handling mechanism
@@ -32,7 +40,7 @@ class SessionProvider extends Provider
 			 */
 			case '':
 			case null:
-				$this->container->set(Session::class, new Session(new FileSessionHandler(session_save_path())));
+				$container->set(Session::class, new Session(new FileSessionHandler(session_save_path())));
 				break;
 			/**
 			 * The user provided a configuration that we cannot associate with any

--- a/src/contracts/services/Provider.php
+++ b/src/contracts/services/Provider.php
@@ -46,7 +46,7 @@ abstract class Provider
 	
 	public function __construct(ContainerInterface $container)
 	{
-		$this->$container = $container;
+		$this->container = $container;
 	}
 	
 	/**


### PR DESCRIPTION
Up until now, PHPStan would issue a warning due to the fact that we're trying to use the set and assemble methods inside the framework on a standard PSR object. Since Spitfire implements the interface and extends it's functionality with setters and other handy methods, the type hinting would suggest that we're using methods on the interface that are not defined.

This code causes Spitfire to actually enforce the use of it's own implementation.

If needed, we could always extract an interface so that alternative implementations are possible.